### PR TITLE
mite-rb update / default https

### DIFF
--- a/lib/mite-rb.rb
+++ b/lib/mite-rb.rb
@@ -1,6 +1,5 @@
 require 'active_support'
 require 'active_resource'
-require 'yaml'
 
 # The official ruby library for interacting with the RESTful API of mite,
 # a sleek time tracking webapp.
@@ -63,20 +62,15 @@ module Mite
     end
   
     def version
-      @version ||= begin
-        config = YAML.load(File.read(File.join(File.dirname(__FILE__), "..", "VERSION.yml")))
-        "#{config[:major]}.#{config[:minor]}.#{config[:patch]}"
-      rescue
-        "0.0.0"
-      end
+      Mite::VERSION
     end
   end
   
   self.host_format   = '%s://%s%s'
   self.domain_format = '%s.mite.yo.lk'
-  self.protocol      = 'http'
+  self.protocol      = 'https'
   self.port          = ''
-  self.user_agent    = "mite-rb/#{Mite.version}"
+  self.user_agent    = "mite-rb/#{Mite::VERSION}"
   
   class MethodNotAvaible < StandardError; end
   

--- a/lib/mite/version.rb
+++ b/lib/mite/version.rb
@@ -1,0 +1,3 @@
+module Mite
+  VERSION = "0.4.1"
+end


### PR DESCRIPTION
Moin Thomas,

hab mite-rb geupdated, da die neuste version per default HTTPS verwendet. Da wir in einem ~1 Monat die mite.api nur noch über HTTPS zulassen würde ich dich bitten eine neue Version von Redmine2mite rauszuhauen.

Danke!
Sebastian.
