### PR TITLE
Add routes configuration for Redmine 1.4+

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,3 @@
+ActionController::Routing::Routes.draw do |map|
+  map.connect '/mite/:action/:id', :controller => 'mite'
+end


### PR DESCRIPTION
From http://www.redmine.org/projects/redmine/wiki/Plugin_Tutorial#Generating-a-controller:

  Starting from 1.4.0, Redmine won't provide anymore the default
  wildcard route (':controller/:action/:id'). Plugins will have to
  declare the routes they need in their proper config/routes.rb file.

This commit contains the required route configuration.
