### PR TITLE
Limit request size to api in MiteSynchronizer::TimeEntries remote_records

### DIFF
--- a/lib/mite_synchronizers/time_entries.rb
+++ b/lib/mite_synchronizers/time_entries.rb
@@ -38,7 +38,10 @@ class MiteSynchronizer::TimeEntries < MiteSynchronizer::Base
   
   def remote_records
     return [] unless local_records.any?
-    @remote_records ||= Mite::TimeEntry.find(:all, :params => {:ids => local_records.map(&:mite_time_entry_id).join(",")})
+    local_records.map(&:mite_time_entry_id).each_slice(500) {
+      |i|
+      @remote_records ||= Mite::TimeEntry.find(:all, :params => {:ids => i.join(",")})
+    }
   end
     
   def local_records


### PR DESCRIPTION
We had the case that over 1000 id's had to be synced which failed permanently. 
After a long debugging session I figured out that the request size is exceeded if around 700 ids are used for `Mite::TimeEntry.find()`.
If the request limit is exceeded you'll get an error like this `Net::HTTPBadResponse: wrong status line:` - but to see it you've to add a logger to `MiteController::save_account_data()`

I tried to workaround this issue by adding a loop - but frankly speaking I've no clue of ruby.
From an architecture point of view the fix also should be located in `Mite::TimeEntry` or even `Mite` and not in `MiteSynchronizer::TimeEntries`.
But to solve it the right way I've simply not enough ruby knowledge ;)

However it would be nice if the change or an enhanced version of it would get pulled into the official branch.

Thank you very much & best regards
Peter
