### PR TITLE
Fixed bug in MiteSynchronizer::TimeEntries with more than 500 entries

### DIFF
--- a/lib/mite_synchronizers/time_entries.rb
+++ b/lib/mite_synchronizers/time_entries.rb
@@ -37,9 +37,10 @@ class MiteSynchronizer::TimeEntries < MiteSynchronizer::Base
   end
   
   def remote_records
-    return [] unless local_records.any?
+    return @remote_records if @remote_records
+    @remote_records = []
     local_records.map(&:mite_time_entry_id).each_slice(500) do |i|
-      @remote_records ||= Mite::TimeEntry.find(:all, :params => {:ids => i.join(",")})
+      @remote_records += Mite::TimeEntry.find(:all, :params => {:ids => i.join(",")})
     end
     @remote_records
   end


### PR DESCRIPTION
Hi Thomas,

ein mite-Kunde hatte sich gestern bei uns gemeldet, dass redmine2mite Zeiteinträge in mite beim Synchronisieren fälschlicherweise gelöscht hätte. 

Ich bin mal in denen Code getaucht und habe einen Fehler in MiteSynchronizer::TimeEntries#remote_records gefunden: Dort wurden alle Einträge nach den ersten 500 ignoriert.

Anbei ein Fix für das Problem. Wäre super wenn du recht schnell 2.1.1 rausbringen könntest.

Danke & ein schönes Wochenende,
Sebastian.
